### PR TITLE
remove unnecessary crypto package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microservice/auth-token",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Microservice authentication tokens",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,6 @@
   "author": "Doug Moscrop <doug.moscrop@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "crypto": "0.0.3",
     "jwt-simple": "^0.3.0",
     "object-assign": "^4.0.1"
   },


### PR DESCRIPTION
See https://medium.com/@rmehlinger/crypto-collision-f41c206de27b. This package has no license and no tests, and masks a built in NodeJS library. Thankfully, Node does not allow its crypto package to be overwritten by this thing, so requiring it doesn't actually do anything.